### PR TITLE
Fix type Float32Array type check in Utils

### DIFF
--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -49,7 +49,7 @@ Utils.splice = function(array,index,howmany){
 
 //Check the type explicit to prevent IE errors
 //Utils.ARRAY_TYPE = Float32Array || Array;
-if (typeof Float32Array !== undefined){
+if (typeof Float32Array !== 'undefined'){
   Utils.ARRAY_TYPE = Float32Array;
 }else{
   Utils.ARRAY_TYPE = Array;


### PR DESCRIPTION
You can't do it like this. You have to use typeof, otherwise you get an undefined error.

```
Utils.ARRAY_TYPE = Float32Array || Array;
```

changed to:

```
if (typeof Float32Array !== 'undefined'){
  Utils.ARRAY_TYPE = Float32Array;
}else{
  Utils.ARRAY_TYPE = Array;
}
```
