### PR TITLE
fix perf issues with FF & TupleDictionary

### DIFF
--- a/src/utils/TupleDictionary.js
+++ b/src/utils/TupleDictionary.js
@@ -11,9 +11,9 @@ function TupleDictionary() {
     /**
      * The data storage
      * @property data
-     * @type {Array}
+     * @type {Object}
      */
-    this.data = [];
+    this.data = {};
 
     /**
      * Keys that are currently used.
@@ -90,8 +90,15 @@ TupleDictionary.prototype.set = function(i, j, value) {
  * @method reset
  */
 TupleDictionary.prototype.reset = function() {
-    this.data.length = 0;
-    this.keys.length = 0;
+    var data = this.data,
+        keys = this.keys;
+
+    var l = keys.length;
+    while(l--) {
+        delete data[keys[l]];
+    }
+
+    keys.length = 0;
 };
 
 /**


### PR DESCRIPTION
Using an object instead of an array for TupleDictionary data seems to fix the performance issues introduced in #81. Not sure why that was an issue in FF, but like I said in that PR an object would make more sense here anyway.

Hopefully this will help to fix #95 as well.
