### PR TITLE
Material: allow custom id & do checks by id

### DIFF
--- a/src/material/Material.js
+++ b/src/material/Material.js
@@ -4,16 +4,16 @@ module.exports = Material;
  * Defines a physics material.
  * @class Material
  * @constructor
- * @param string name
+ * @param {number} material identifier
  * @author schteppe
  */
-function Material(){
+function Material(id){
     /**
      * The material identifier
      * @property id
      * @type {Number}
      */
-    this.id = Material.idCounter++;
+    this.id = id || Material.idCounter++;
 };
 
 Material.idCounter = 0;

--- a/src/world/World.js
+++ b/src/world/World.js
@@ -435,8 +435,8 @@ World.prototype.getContactMaterial = function(materialA,materialB){
     var cmats = this.contactMaterials;
     for(var i=0, N=cmats.length; i!==N; i++){
         var cm = cmats[i];
-        if( (cm.materialA === materialA) && (cm.materialB === materialB) ||
-            (cm.materialA === materialB) && (cm.materialB === materialA) ){
+        if( (cm.materialA.id === materialA.id) && (cm.materialB.id === materialB.id) ||
+            (cm.materialA.id === materialB.id) && (cm.materialB.id === materialA.id) ){
             return cm;
         }
     }


### PR DESCRIPTION
This allows you do things were you may need to have separate material instances that should be treated as if they were identical.

When running in node.js, you don't have the same kind of globals, and so it is necessary for sanity to do something like having a `module.exports.material = new Material(300)` in, say, `Ship.js` that can be checked via id, because a new version is made each time it is imported. 
(this is primarily so that you can sanely set up ContactMaterials between entities defined in different files)
