### PR TITLE
Fix for requirejs via phaser

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,8 +11,7 @@ module.exports = function(grunt) {
                 dest : 'build/p2.js',
                 options:{
                     bundleOptions : {
-                        standalone : "p2",
-                        insertGlobals: true
+                        standalone : "p2"
                     }
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,8 @@ module.exports = function(grunt) {
                 dest : 'build/p2.js',
                 options:{
                     bundleOptions : {
-                        standalone : "p2"
+                        standalone : "p2",
+                        insertGlobals: true
                     }
                 }
             }

--- a/src/p2.js
+++ b/src/p2.js
@@ -1,5 +1,5 @@
 // Export p2 classes
-module.exports = {
+var p2 = module.exports = {
     AABB :                          require('./collision/AABB'),
     AngleLockEquation :             require('./equations/AngleLockEquation'),
     Body :                          require('./objects/Body'),


### PR DESCRIPTION
Fixed compatibility with phaser and requirejs. Seems that phaser uses p2 globally, and when included with requirejs, it fails to pickup the global p2.