### PR TITLE
Small docs fix and removing unused require()

### DIFF
--- a/src/world/World.js
+++ b/src/world/World.js
@@ -57,7 +57,7 @@ if(!performance.now){
  * @param {Object} [options]
  * @param {Solver} [options.solver] Defaults to GSSolver.
  * @param {Array} [options.gravity] Defaults to y=-9.78.
- * @param {Broadphase} [options.broadphase] Defaults to NaiveBroadphase
+ * @param {Broadphase} [options.broadphase] Defaults to SAPBroadphase
  * @param {Boolean} [options.islandSplit=true]
  * @param {Boolean} [options.doProfiling=false]
  * @extends EventEmitter

--- a/src/world/World.js
+++ b/src/world/World.js
@@ -3,7 +3,6 @@
 
 var  GSSolver = require('../solver/GSSolver')
 ,    Solver = require('../solver/Solver')
-,    NaiveBroadphase = require('../collision/NaiveBroadphase')
 ,    Ray = require('../collision/Ray')
 ,    vec2 = require('../math/vec2')
 ,    Circle = require('../shapes/Circle')


### PR DESCRIPTION
The comment for World constructor says default broadphase is NaiveBroadphase but on [World.js line 172](https://github.com/schteppe/p2.js/blob/master/src/world/World.js#L172) it's defaulting to SAPBroadphase.

Also I noticed that NaiveBroadphase is not used in that file so I removed the `require()` for it.