### PR TITLE
Added a factory method on Line that creates a line between two points

### DIFF
--- a/src/collision/Narrowphase.js
+++ b/src/collision/Narrowphase.js
@@ -191,7 +191,7 @@ Narrowphase.prototype.bodiesOverlap = function(bodyA, bodyB){
 
         bodyA.toWorldFrame(shapePositionA, positionA);
 
-        // All shapes of body j
+        // All shapes of bodyB
         for(var l=0, Nshapesj=bodyB.shapes.length; l!==Nshapesj; l++){
             var shapeB = bodyB.shapes[l],
                 positionB = bodyB.shapeOffsets[l],
@@ -685,13 +685,8 @@ Narrowphase.prototype.planeLine = function(planeBody, planeShape, planeOffset, p
         verts = tmpArray,
         numContacts = 0;
 
-    // Get start and end points
-    vec2.set(worldVertex0, -lineShape.length/2, 0);
-    vec2.set(worldVertex1,  lineShape.length/2, 0);
-
-    // Not sure why we have to use worldVertex*1 here, but it won't work otherwise. Tired.
-    vec2.rotate(worldVertex01, worldVertex0, lineAngle);
-    vec2.rotate(worldVertex11, worldVertex1, lineAngle);
+    vec2.rotate(worldVertex01, lineShape.points[0], lineAngle);
+    vec2.rotate(worldVertex11, lineShape.points[1], lineAngle);
 
     add(worldVertex01, worldVertex01, lineOffset);
     add(worldVertex11, worldVertex11, lineOffset);
@@ -829,13 +824,8 @@ Narrowphase.prototype.circleLine = function(
 
         verts = tmpArray;
 
-    // Get start and end points
-    vec2.set(worldVertex0, -lineShape.length/2, 0);
-    vec2.set(worldVertex1,  lineShape.length/2, 0);
-
-    // Not sure why we have to use worldVertex*1 here, but it won't work otherwise. Tired.
-    vec2.rotate(worldVertex01, worldVertex0, lineAngle);
-    vec2.rotate(worldVertex11, worldVertex1, lineAngle);
+    vec2.rotate(worldVertex01, lineShape.points[0], lineAngle);
+    vec2.rotate(worldVertex11, lineShape.points[1], lineAngle);
 
     add(worldVertex01, worldVertex01, lineOffset);
     add(worldVertex11, worldVertex11, lineOffset);

--- a/src/shapes/Capsule.js
+++ b/src/shapes/Capsule.js
@@ -30,6 +30,14 @@ function Capsule(length, radius){
      */
     this.radius = radius || 1;
 
+    // Because Capsule uses the same collision codepath as
+    // Line we construct points used by the line narrowphase
+    var halfLength = this.length / 2;
+    this.points = [
+        vec2.fromValues(-halfLength, 0),
+        vec2.fromValues( halfLength, 0)
+    ];
+
     Shape.call(this,Shape.CAPSULE);
 }
 Capsule.prototype = new Shape();

--- a/src/shapes/Line.js
+++ b/src/shapes/Line.js
@@ -10,7 +10,7 @@ module.exports = Line;
  * @extends Shape
  * @constructor
  */
-function Line(length){
+function Line(length) {
 
     /**
      * Length of this line
@@ -20,20 +20,45 @@ function Line(length){
      */
     this.length = length || 1;
 
-    Shape.call(this,Shape.LINE);
+    var halfLength = this.length / 2;
+    this.points = [
+        vec2.fromValues(-halfLength, 0),
+        vec2.fromValues( halfLength, 0)
+    ];
+
+    Shape.call(this, Shape.LINE);
 }
 Line.prototype = new Shape();
 Line.prototype.constructor = Line;
 
-Line.prototype.computeMomentOfInertia = function(mass){
+/**
+ * Constructs a line segment between two points
+ * @method fromPoints
+ * @param  {Number} x1 The x coordinate of the first point
+ * @param  {Number} y1 The y coordinate of the first point
+ * @param  {Number} x2 The x coordinate of the second point
+ * @param  {Number} y2 The y coordinate of the second point
+ */
+Line.fromPoints = function(x1, y1, x2, y2) {
+    var line = new Line();
+
+    vec2.set(line.points[0], x1, y1);
+    vec2.set(line.points[1], x2, y2);
+
+    var dx = x2 - x1;
+    var dy = y2 - y1;
+    line.length = Math.sqrt(dx*dx + dy*dy);
+
+    return line;
+};
+
+Line.prototype.computeMomentOfInertia = function(mass) {
     return mass * Math.pow(this.length,2) / 12;
 };
 
-Line.prototype.updateBoundingRadius = function(){
+Line.prototype.updateBoundingRadius = function() {
     this.boundingRadius = this.length/2;
 };
-
-var points = [vec2.create(),vec2.create()];
 
 /**
  * @method computeAABB
@@ -41,10 +66,6 @@ var points = [vec2.create(),vec2.create()];
  * @param  {Array}  position
  * @param  {Number} angle
  */
-Line.prototype.computeAABB = function(out, position, angle){
-    var l2 = this.length / 2;
-    vec2.set(points[0], -l2,  0);
-    vec2.set(points[1],  l2,  0);
-    out.setFromPoints(points,position,angle,0);
+Line.prototype.computeAABB = function(out, position, angle) {
+    out.setFromPoints(this.points, position, angle, 0);
 };
-

--- a/test/shapes/Capsule.js
+++ b/test/shapes/Capsule.js
@@ -1,9 +1,11 @@
-var Capsule = require(__dirname + '/../../src/shapes/Capsule');
+var Capsule = require(__dirname + '/../../src/shapes/Capsule')
+,   vec2 = require(__dirname + '/../../src/math/vec2');
 
 exports.construct = function(test){
     var capsule = new Capsule(2,3);
     test.equal(capsule.length, 2);
     test.equal(capsule.radius, 3);
+    test.deepEqual(capsule.points, [vec2.fromValues(-1, 0), vec2.fromValues(1, 0)]);
     test.done();
 };
 
@@ -16,4 +18,3 @@ exports.conputeMomentOfInertia = function(test){
     // STUB
     test.done();
 };
-

--- a/test/shapes/Line.js
+++ b/test/shapes/Line.js
@@ -1,17 +1,34 @@
-var Line = require(__dirname + '/../../src/shapes/Line');
+var Line = require(__dirname + '/../../src/shapes/Line')
+,   vec2 = require(__dirname + '/../../src/math/vec2')
+,   AABB = require(__dirname + '/../../src/collision/AABB');
 
 exports.construct = function(test){
     var line = new Line(2);
     test.equal(line.length, 2);
+    test.deepEqual(line.points, [vec2.fromValues(-1, 0), vec2.fromValues(1, 0)]);
 
     line = new Line();
     test.equal(line.length, 1);
+    test.deepEqual(line.points, [vec2.fromValues(-.5, 0), vec2.fromValues(.5, 0)]);
 
     test.done();
 };
 
+exports.fromPoints = function(test) {
+    line = Line.fromPoints(10, 10, 13, 14);
+    test.equal(line.length, 5);
+    test.deepEqual(line.points, [vec2.fromValues(10, 10), vec2.fromValues(13, 14)]);
+    test.done();
+};
+
 exports.computeAABB = function(test){
-    // STUB
+    var aabb = new AABB();
+    var line = Line.fromPoints(10, 10, 13, 14);
+    line.computeAABB(aabb, vec2.fromValues(100, 100), 0);
+
+    test.deepEqual(aabb.lowerBound, vec2.fromValues(110, 110));
+    test.deepEqual(aabb.upperBound, vec2.fromValues(113, 114));
+
     test.done();
 };
 


### PR DESCRIPTION
This was something I used in my own project to build line segments between two points. I'm not sure if this has any interest but I figured I would make a PR none the less :)

Also in this PR:
- `Line` instances now takes up a bit more memory because each line point is stored. On the other hand this frees up some CPU on runtime as the points doesn't need to be calculated during narrowphase.
- AABB calculation of `Line` is now somewhat tested.