### PR TITLE
Docs fix: setBrakeForce

### DIFF
--- a/src/objects/TopDownVehicle.js
+++ b/src/objects/TopDownVehicle.js
@@ -177,7 +177,7 @@ function WheelConstraint(vehicle, options){
 WheelConstraint.prototype = new Constraint();
 
 /**
- * @method setForwardFriction
+ * @method setBrakeForce
  */
 WheelConstraint.prototype.setBrakeForce = function(force){
     this.forwardEquation.setSlipForce(force);


### PR DESCRIPTION
Small change so that `setBrakeForce` will be in the generated docs page of `WheelConstraint`.