### PR TITLE
Improve docs for applyForce and applyImpulse on Body

### DIFF
--- a/src/math/vec2.js
+++ b/src/math/vec2.js
@@ -161,8 +161,8 @@ vec2.vectorToLocalFrame = function(out, worldVector, frameAngle){
 };
 
 /**
- * Transform a point position to global frame.
- * @method toGlobalFrame
+ * Transform a vector to global frame.
+ * @method vectorToGlobalFrame
  * @param  {Array} out
  * @param  {Array} localVector
  * @param  {Number} frameAngle

--- a/src/objects/Body.js
+++ b/src/objects/Body.js
@@ -656,10 +656,10 @@ Body.prototype.updateMassProperties = function(){
 };
 
 /**
- * Apply force to a point relative to the center of mass of the body. This could for example be a point on the RigidBody surface. Applying force this way will add to Body.force and Body.angularForce. If relativePoint is zero, the force will be applied directly on the center of mass, and the torque produced will be zero.
+ * Apply force to a point relative to the center of mass of the body. This could for example be a point on the Body surface. Applying force this way will add to Body.force and Body.angularForce.
  * @method applyForce
- * @param {Array} force The force to add.
- * @param {Array} [relativePoint] A world point to apply the force on.
+ * @param  {Array} force The force vector to add, oriented in world space.
+ * @param  {Array} [relativePoint] A point relative to the body in world space. If not given, it is set to zero and all of the force will be exerted on the center of mass.
  */
 Body.prototype.applyForce = function(force, relativePoint){
 
@@ -677,10 +677,10 @@ Body.prototype.applyForce = function(force, relativePoint){
 };
 
 /**
- * Apply force to a body-local point.
+ * Apply force to a point relative to the center of mass of the body. This could for example be a point on the Body surface. Applying force this way will add to Body.force and Body.angularForce.
  * @method applyForceLocal
  * @param  {Array} localForce The force vector to add, oriented in local body space.
- * @param  {Array} [localPoint] A point relative to the body in world space. If not given, it is set to zero and all of the impulse will be excerted on the center of mass.
+ * @param  {Array} [localPoint] A point relative to the body in local body space. If not given, it is set to zero and all of the force will be exerted on the center of mass.
  */
 var Body_applyForce_forceWorld = vec2create();
 var Body_applyForce_pointWorld = vec2create();
@@ -697,8 +697,8 @@ Body.prototype.applyForceLocal = function(localForce, localPoint){
 /**
  * Apply impulse to a point relative to the body. This could for example be a point on the Body surface. An impulse is a force added to a body during a short period of time (impulse = force * time). Impulses will be added to Body.velocity and Body.angularVelocity.
  * @method applyImpulse
- * @param  {Array} impulse The impulse vector to add, oriented in world space.
- * @param  {Array} [relativePoint] A point relative to the body in world space. If not given, it is set to zero and all of the impulse will be excerted on the center of mass.
+ * @param  {Array} impulseVector The impulse vector to add, oriented in world space.
+ * @param  {Array} [relativePoint] A point relative to the body in world space. If not given, it is set to zero and all of the impulse will be exerted on the center of mass.
  */
 var Body_applyImpulse_velo = vec2create();
 Body.prototype.applyImpulse = function(impulseVector, relativePoint){
@@ -727,8 +727,8 @@ Body.prototype.applyImpulse = function(impulseVector, relativePoint){
 /**
  * Apply impulse to a point relative to the body. This could for example be a point on the Body surface. An impulse is a force added to a body during a short period of time (impulse = force * time). Impulses will be added to Body.velocity and Body.angularVelocity.
  * @method applyImpulseLocal
- * @param  {Array} impulse The impulse vector to add, oriented in world space.
- * @param  {Array} [relativePoint] A point relative to the body in world space. If not given, it is set to zero and all of the impulse will be excerted on the center of mass.
+ * @param  {Array} localImpulse The impulse vector to add, oriented in local body space.
+ * @param  {Array} [localPoint] A point relative to the body in local body space. If not given, it is set to zero and all of the impulse will be exerted on the center of mass.
  */
 var Body_applyImpulse_impulseWorld = vec2create();
 var Body_applyImpulse_pointWorld = vec2create();

--- a/src/objects/Body.js
+++ b/src/objects/Body.js
@@ -745,7 +745,7 @@ Body.prototype.applyImpulseLocal = function(localImpulse, localPoint){
 /**
  * Transform a world point to local body frame.
  * @method toLocalFrame
- * @param  {Array} out          The vector to store the result in
+ * @param  {Array} out          The point to store the result in
  * @param  {Array} worldPoint   The input world point
  */
 Body.prototype.toLocalFrame = function(out, worldPoint){
@@ -755,7 +755,7 @@ Body.prototype.toLocalFrame = function(out, worldPoint){
 /**
  * Transform a local point to world frame.
  * @method toWorldFrame
- * @param  {Array} out          The vector to store the result in
+ * @param  {Array} out          The point to store the result in
  * @param  {Array} localPoint   The input local point
  */
 Body.prototype.toWorldFrame = function(out, localPoint){
@@ -763,7 +763,7 @@ Body.prototype.toWorldFrame = function(out, localPoint){
 };
 
 /**
- * Transform a world point to local body frame.
+ * Transform a world vector to local body frame.
  * @method vectorToLocalFrame
  * @param  {Array} out          The vector to store the result in
  * @param  {Array} worldVector  The input world vector
@@ -773,7 +773,7 @@ Body.prototype.vectorToLocalFrame = function(out, worldVector){
 };
 
 /**
- * Transform a local point to world frame.
+ * Transform a local vector to world frame.
  * @method vectorToWorldFrame
  * @param  {Array} out          The vector to store the result in
  * @param  {Array} localVector  The input local vector


### PR DESCRIPTION
I was trying to work out how I could use p2 to apply off-centre thrust to a body and the docs got me into a bit of a spin.

I dug into the code and I think these changes bring the docs inline with the actual behaviour. If not, I've definitely misunderstood things!

I can squash these commits down or split them out a little bit more (e9b297a is really 4 changes, but it seemed over the top to have it as four commits) – is there a style you prefer for contributions?

I couldn't find a way to build the docs; running `grunt` builds all the JS files but not the doc files. Since the built JS files contain a lot of changes that aren't the ones I've made, I'm assuming you handle the build and commit as a separate step when you want to cut a release, and that the doc build will be part of that. If that's not the case, please let me know.