### PR TITLE
Fix ConvexOptions definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -661,8 +661,8 @@ declare module p2 {
 
     export interface ConvexOptions extends SharedShapeOptions {
 
-      length?: number;
-      radius?: number;
+      vertices?: number[][];
+      axes?: number[][];
 
     }
 


### PR DESCRIPTION
Looks like the definition for p2.ConvexOptions was copied from another one and not updated. See http://schteppe.github.io/p2.js/docs/classes/Convex.html