### PR TITLE
Remove unused variables from constraints demo

### DIFF
--- a/demos/constraints.html
+++ b/demos/constraints.html
@@ -79,8 +79,6 @@
             });
             bodyB.addShape(new p2.Circle({ radius: 1 }));
             world.addBody(bodyB);
-            var pivotA = [0,2];
-            var pivotB = [0,-2];
             var cr = new p2.RevoluteConstraint(bodyA, bodyB, {
                 worldPivot: [3, 2]
             });


### PR DESCRIPTION
A minor tidy up found whilst looking into how constraints worked so I can make a rope.

The commit 47719071f748e38e9455d97b0b0be2ae2cd99c5d stopped using these variables when the interface for `RevoluteConstraint` changed to accept a `worldPivot`.