### PR TITLE
TypeScript: Make ContractMaterialOptions properties optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -346,15 +346,15 @@ declare module p2 {
 
     }
 
-    export class ContactMaterialOptions {
+    export interface ContactMaterialOptions {
 
-        friction: number;
-        restitution: number;
-        stiffness: number;
-        relaxation: number;
-        frictionStiffness: number;
-        frictionRelaxation: number;
-        surfaceVelocity: number;
+        friction?: number;
+        restitution?: number;
+        stiffness?: number;
+        relaxation?: number;
+        frictionStiffness?: number;
+        frictionRelaxation?: number;
+        surfaceVelocity?: number;
 
     }
 


### PR DESCRIPTION
For some reason, `ContactMaterialOptions` was defined as a class of required properties, instead of an interface of optional properties like the other option definitions. This PR brings it in line with the other options so you no longer have to pass all fields to `new ContactMaterial({...})`.