### PR TITLE
Fix constraint constructor arguments for ts typings.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -110,9 +110,7 @@ declare module p2 {
 
     export class DistanceConstraint extends Constraint {
 
-        constructor(bodyA: Body, bodyB: Body, type: number, options?: {
-            collideConnected?: boolean;
-            wakeUpBodies?: boolean;
+        constructor(bodyA: Body, bodyB: Body, options?: {
             distance?: number;
             localAnchorA?: number[];
             localAnchorB?: number[];
@@ -136,9 +134,7 @@ declare module p2 {
 
     export class GearConstraint extends Constraint {
 
-        constructor(bodyA: Body, bodyB: Body, type: number, options?: {
-            collideConnected?: boolean;
-            wakeUpBodies?: boolean;
+        constructor(bodyA: Body, bodyB: Body, options?: {
             angle?: number;
             ratio?: number;
             maxTorque?: number;
@@ -154,9 +150,7 @@ declare module p2 {
 
     export class LockConstraint extends Constraint {
 
-        constructor(bodyA: Body, bodyB: Body, type: number, options?: {
-            collideConnected?: boolean;
-            wakeUpBodies?: boolean;
+        constructor(bodyA: Body, bodyB: Body, options?: {
             localOffsetB?: number[];
             localAngleB?: number;
             maxForce?: number;
@@ -169,9 +163,7 @@ declare module p2 {
 
     export class PrismaticConstraint extends Constraint {
 
-        constructor(bodyA: Body, bodyB: Body, type: number, options?: {
-            collideConnected?: boolean;
-            wakeUpBodies?: boolean;
+        constructor(bodyA: Body, bodyB: Body, options?: {
             maxForce?: number;
             localAnchorA?: number[];
             localAnchorB?: number[];
@@ -204,9 +196,7 @@ declare module p2 {
 
     export class RevoluteConstraint extends Constraint {
 
-        constructor(bodyA: Body, bodyB: Body, type: number, options?: {
-            collideConnected?: boolean;
-            wakeUpBodies?: boolean;
+        constructor(bodyA: Body, bodyB: Body, options?: {
             worldPivot?: number[];
             localPivotA?: number[];
             localPivotB?: number[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -111,6 +111,8 @@ declare module p2 {
     export class DistanceConstraint extends Constraint {
 
         constructor(bodyA: Body, bodyB: Body, options?: {
+            collideConnected?: boolean;
+            wakeUpBodies?: boolean;
             distance?: number;
             localAnchorA?: number[];
             localAnchorB?: number[];
@@ -135,6 +137,8 @@ declare module p2 {
     export class GearConstraint extends Constraint {
 
         constructor(bodyA: Body, bodyB: Body, options?: {
+            collideConnected?: boolean;
+            wakeUpBodies?: boolean;
             angle?: number;
             ratio?: number;
             maxTorque?: number;
@@ -151,6 +155,8 @@ declare module p2 {
     export class LockConstraint extends Constraint {
 
         constructor(bodyA: Body, bodyB: Body, options?: {
+            collideConnected?: boolean;
+            wakeUpBodies?: boolean;
             localOffsetB?: number[];
             localAngleB?: number;
             maxForce?: number;
@@ -164,6 +170,8 @@ declare module p2 {
     export class PrismaticConstraint extends Constraint {
 
         constructor(bodyA: Body, bodyB: Body, options?: {
+            collideConnected?: boolean;
+            wakeUpBodies?: boolean;
             maxForce?: number;
             localAnchorA?: number[];
             localAnchorB?: number[];
@@ -197,6 +205,8 @@ declare module p2 {
     export class RevoluteConstraint extends Constraint {
 
         constructor(bodyA: Body, bodyB: Body, options?: {
+            collideConnected?: boolean;
+            wakeUpBodies?: boolean;
             worldPivot?: number[];
             localPivotA?: number[];
             localPivotB?: number[];


### PR DESCRIPTION
Detected an issue with typescript typings for constraints constructors:
http://schteppe.github.io/p2.js/docs/classes/DistanceConstraint.html
http://schteppe.github.io/p2.js/docs/classes/GearConstraint.html
http://schteppe.github.io/p2.js/docs/classes/LockConstraint.html
http://schteppe.github.io/p2.js/docs/classes/PrismaticConstraint.html
http://schteppe.github.io/p2.js/docs/classes/RevoluteConstraint.html