### PR TITLE
Adding grunt-cli to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-browserify": "~2.0.1",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-nodeunit": "^0.4.1",


### PR DESCRIPTION
It looks like you were relying on a locally installed global grunt-cli
package, which is the package that lets you use grunt at the command
line. Adding it to this package explicitly to avoid falling back to
user's global npm libraries.