### PR TITLE
Remove pointless argument when creating World's Narrowphase

### DIFF
--- a/src/world/World.js
+++ b/src/world/World.js
@@ -72,7 +72,7 @@ function World(options){
      * @property narrowphase
      * @type {Narrowphase}
      */
-    this.narrowphase = new Narrowphase(this);
+    this.narrowphase = new Narrowphase();
 
     /**
      * The island manager of this world.


### PR DESCRIPTION
`Narrowphase`'s constructor does not expect any arguments. Unless I'm mistaken / didn't check enough.