### PR TITLE
Remove unused tuple dictionaries in World instances

### DIFF
--- a/src/world/World.js
+++ b/src/world/World.js
@@ -229,10 +229,6 @@ function World(options){
     this._constraintIdCounter = 0;
     this._bodyIdCounter = 0;
 
-    // For keeping track of overlapping shapes
-    this.overlappingShapesLastState = { keys:[] };
-    this.overlappingShapesCurrentState = { keys:[] };
-
     /**
      * @property {OverlapKeeper} overlapKeeper
      */


### PR DESCRIPTION
`OverlapKeeper` instances its own `TupleDictionary`ies in its constructor. These ones are unused.
(afaik)