### PR TITLE
Fix to narrowphase.bodiesOverlap() to make sure shapes are passed into collision methods in the right order

### DIFF
--- a/src/collision/Narrowphase.js
+++ b/src/collision/Narrowphase.js
@@ -151,18 +151,37 @@ Narrowphase.prototype.bodiesOverlap = function(bodyA, bodyB, checkCollisionMasks
             bodyA.toWorldFrame(shapePositionA, shapeA.position);
             bodyB.toWorldFrame(shapePositionB, shapeB.position);
 
-            if(this[shapeA.type | shapeB.type](
-                bodyA,
-                shapeA,
-                shapePositionA,
-                shapeA.angle + bodyA.angle,
-                bodyB,
-                shapeB,
-                shapePositionB,
-                shapeB.angle + bodyB.angle,
-                true
-            )){
-                return true;
+            if(shapeA.type <= shapeB.type)
+            {
+                if(this[shapeA.type | shapeB.type](
+                    bodyA,
+                    shapeA,
+                    shapePositionA,
+                    shapeA.angle + bodyA.angle,
+                    bodyB,
+                    shapeB,
+                    shapePositionB,
+                    shapeB.angle + bodyB.angle,
+                    true
+                )){
+                    return true;
+                }
+            }
+            else
+            {
+                if(this[shapeA.type | shapeB.type](
+                    bodyB,
+                    shapeB,
+                    shapePositionB,
+                    shapeB.angle + bodyB.angle,
+                    bodyA,
+                    shapeA,
+                    shapePositionA,
+                    shapeA.angle + bodyA.angle,
+                    true
+                )){
+                    return true;
+                }
             }
         }
     }
@@ -325,7 +344,7 @@ Narrowphase.prototype.createFrictionFromAverage = function(numContacts){
  * @param {boolean}     justTest
  * @todo Implement me!
  */
-Narrowphase.prototype[Shape.LINE | Shape.CONVEX] =
+Narrowphase.prototype[Shape.CONVEX | Shape.LINE] =
 Narrowphase.prototype.convexLine = function(
     convexBody,
     convexShape,
@@ -404,8 +423,8 @@ var convexCapsule_tempRect = new Box({ width: 1, height: 1 }),
  * @param  {Array}      capsulePosition
  * @param  {Number}     capsuleAngle
  */
-Narrowphase.prototype[Shape.CAPSULE | Shape.CONVEX] =
-Narrowphase.prototype[Shape.CAPSULE | Shape.BOX] =
+Narrowphase.prototype[Shape.CONVEX | Shape.CAPSULE] =
+Narrowphase.prototype[Shape.BOX | Shape.CAPSULE] =
 Narrowphase.prototype.convexCapsule = function(
     convexBody,
     convexShape,
@@ -455,7 +474,7 @@ Narrowphase.prototype.convexCapsule = function(
  * @param  {Number}     capsuleAngle
  * @todo Implement me!
  */
-Narrowphase.prototype[Shape.CAPSULE | Shape.LINE] =
+Narrowphase.prototype[Shape.LINE | Shape.CAPSULE] =
 Narrowphase.prototype.lineCapsule = function(
     lineBody,
     lineShape,
@@ -491,7 +510,7 @@ var capsuleCapsule_tempRect1 = new Box({ width: 1, height: 1 });
  * @param  {Array}      xj
  * @param  {Number}     aj
  */
-Narrowphase.prototype[Shape.CAPSULE | Shape.CAPSULE] =
+Narrowphase.prototype[Shape.CAPSULE] =
 Narrowphase.prototype.capsuleCapsule = function(bi,si,xi,ai, bj,sj,xj,aj, justTest){
 
     var enableFrictionBefore;
@@ -594,7 +613,7 @@ Narrowphase.prototype.capsuleCapsule = function(bi,si,xi,ai, bj,sj,xj,aj, justTe
  * @param  {Number}     angleB
  * @todo Implement me!
  */
-Narrowphase.prototype[Shape.LINE | Shape.LINE] =
+Narrowphase.prototype[Shape.LINE] =
 Narrowphase.prototype.lineLine = function(
     bodyA,
     shapeA,


### PR DESCRIPTION
I ran into a crash calling narrowphase.bodiesOverlap() this morning that was due to Narrowphase.prototype.circleConvex being called with the convex being passed in as the circle shape, and the circle shape being passed in as the convex parameters. After looking around in the code, I couldn't figure out what should be preventing this from happening but couldn't find anything. Maybe I'm missing something, but this seems like this bug should happen pretty much half the time mixed collider shapes are tested for overlap. I forked and fixed the issue by checking which order the shapes are expected to be passed into the narrowphase collider function. I'm making a pull request for this in case it's useful to anyone else someday.