### PR TITLE
Adjustments to the buoyancy demo to make the code more easily reusable

### DIFF
--- a/demos/buoyancy.html
+++ b/demos/buoyancy.html
@@ -86,7 +86,7 @@
                     } else if(aabb.lowerBound[1] < planePosition[1]){
                         // Partially submerged
                         var width = aabb.upperBound[0] - aabb.lowerBound[0];
-                        var height = 0 - aabb.lowerBound[1];
+                        var height = planePosition[1] - aabb.lowerBound[1];
                         areaUnderWater = width * height;
                         p2.vec2.set(centerOfBouyancy, aabb.lowerBound[0] + width / 2, aabb.lowerBound[1] + height / 2);
                     } else {

--- a/demos/buoyancy.html
+++ b/demos/buoyancy.html
@@ -95,7 +95,7 @@
 
                     // Compute lift force
                     p2.vec2.subtract(liftForce, planePosition, centerOfBouyancy);
-                    p2.vec2.scale(liftForce, liftForce, areaUnderWater * k);
+                    p2.vec2.scale(liftForce, liftForce, areaUnderWater * k / body.shapes.length);
                     liftForce[0] = 0;
 
                     // Make center of bouycancy relative to the body
@@ -103,7 +103,7 @@
 
                     // Viscous force
                     body.getVelocityAtPoint(v, centerOfBouyancy);
-                    p2.vec2.scale(viscousForce, v, -c);
+                    p2.vec2.scale(viscousForce, v, -c / body.shapes.length);
 
                     // Apply forces
                     body.applyForce(viscousForce,centerOfBouyancy);


### PR DESCRIPTION
I was using the buoyancy demo as a template for my own water simulation code, but I was tripped up on some simple edge cases that were not accounted for in the demo.

This pull request includes "fixes" for those edge cases, so that others might not get caught by them when copying this code.  First, the submerged-area calculation hard-coded the water plane position  (14728c0).  Second, the forces were disproportionately calculated for bodies with different numbers of shapes (fc33f4d).