### PR TITLE
Fast World.contactMaterials lookup

### DIFF
--- a/src/material/ContactMaterial.js
+++ b/src/material/ContactMaterial.js
@@ -116,3 +116,20 @@ function ContactMaterial(materialA, materialB, options){
 }
 
 ContactMaterial.idCounter = 0;
+
+/**
+ * Returns unique hash that was generated based on material id's. Usage: World.contactMaterials[hash].
+ * @private
+ * @method getHash
+ */
+ContactMaterial.prototype.getHash = function(){
+    return ContactMaterial.createHash(this.materialA, this.materialB);
+};
+
+ContactMaterial.createHash = function(materialA, materialB){
+	if (materialA.id <= materialB.id) {
+		return materialA.id + '-' + materialB.id;
+	} else {
+		return materialB.id + '-' + materialA.id;
+	}
+};

--- a/test/world/World.js
+++ b/test/world/World.js
@@ -140,7 +140,7 @@ exports.clear = function(test){
     test.deepEqual(world.bodies, []);
     test.deepEqual(world.springs, []);
     test.deepEqual(world.constraints, []);
-    test.deepEqual(world.contactMaterials, []);
+    test.deepEqual(world.contactMaterials, {});
 
     test.done();
 };


### PR DESCRIPTION
Store ContactMaterials in faster hash map instead of array to lookup ContactMaterials quickly from material id's.

Is it a problem that existing array property has changed type? Or should there be a map from hash to contactMaterials index?