### PR TITLE
Increase range for single id in Tuple (from 16 to 32bits)

### DIFF
--- a/src/utils/TupleDictionary.js
+++ b/src/utils/TupleDictionary.js
@@ -20,6 +20,8 @@ function TupleDictionary() {
      * @property {Array} keys
      */
     this.keys = [];
+    
+    this.tempDataView = new DataView(new ArrayBuffer(8)); //64bits
 }
 
 /**
@@ -30,18 +32,12 @@ function TupleDictionary() {
  * @return {string}
  */
 TupleDictionary.prototype.getKey = function(id1, id2) {
-    id1 = id1|0;
-    id2 = id2|0;
+    if ( id1 === id2 ) return -1;
 
-    if ( (id1|0) === (id2|0) ){
-        return -1;
-    }
+    this.tempDataView.setUint32(0, id1);
+    this.tempDataView.setUint32(4, id2);
 
-    // valid for values < 2^16
-    return ((id1|0) > (id2|0) ?
-        (id1 << 16) | (id2 & 0xFFFF) :
-        (id2 << 16) | (id1 & 0xFFFF))|0
-        ;
+    return this.tempDataView.getFloat64(0);
 };
 
 /**
@@ -50,8 +46,7 @@ TupleDictionary.prototype.getKey = function(id1, id2) {
  * @return {Object}
  */
 TupleDictionary.prototype.getByKey = function(key) {
-    key = key|0;
-    return this.data[key];
+    return this.data[key|0];
 };
 
 /**


### PR DESCRIPTION
Now single id in Tuple can be in higher range (32 bits per id) thanks to ArrayBuffer

first we store each id in ArrayBuffer/DataView(8 bytes = js number) as uint32 at 0 byte and 4 byte
second step is to get key by getting js number (8 bytes from whole buffer)

thats it! :D