### PR TITLE
Fixed inefficient way of resetting an object

### DIFF
--- a/src/utils/TupleDictionary.js
+++ b/src/utils/TupleDictionary.js
@@ -93,15 +93,8 @@ TupleDictionary.prototype.set = function(i, j, value) {
  * @method reset
  */
 TupleDictionary.prototype.reset = function() {
-    var data = this.data,
-        keys = this.keys;
-
-    var l = keys.length;
-    while(l--) {
-        delete data[keys[l]];
-    }
-
-    keys.length = 0;
+    this.keys.length = 0;
+    this.data = {};
 };
 
 /**


### PR DESCRIPTION
Looping through all object keys to delete them is very inefficient, rather remove the reference to the object and create a new object. The garbage collector is efficient enough to handle this.