### PR TITLE
EventEmitter bug fix

### DIFF
--- a/src/events/EventEmitter.js
+++ b/src/events/EventEmitter.js
@@ -15,7 +15,6 @@ module.exports = EventEmitter;
  *     });
  */
 function EventEmitter() {
-    this.tmpArray = [];
 }
 
 EventEmitter.prototype = {
@@ -116,7 +115,7 @@ EventEmitter.prototype = {
             event.target = this;
 
             // Need to copy the listener array, in case some listener was added/removed inside a listener
-            var tmpArray = this.tmpArray;
+            var tmpArray = [];
             for (var i = 0, l = listenerArray.length; i < l; i++) {
                 tmpArray[i] = listenerArray[i];
             }
@@ -124,7 +123,6 @@ EventEmitter.prototype = {
                 var listener = tmpArray[ i ];
                 listener.call( listener.context, event );
             }
-            this.tmpArray.length = 0;
         }
         return this;
     }

--- a/src/events/EventEmitter.js
+++ b/src/events/EventEmitter.js
@@ -124,7 +124,7 @@ EventEmitter.prototype = {
                 var listener = tmpArray[ i ];
                 listener.call( listener.context, event );
             }
-            tmpArray.length = 0;
+            this.tmpArray.length = 0;
         }
         return this;
     }


### PR DESCRIPTION
this.tmpArray was not cleaned after every event emission. This caused listeners to leak to the events they don't belong to and crash the app. 

By the way, do we really need to store tmpArray globally (this.tmpArray)? Maybe just create an empty local tmpArray every time?