### PR TITLE
Fix World.step reverting to fixed time step with 0 timeSinceLastCalled

### DIFF
--- a/src/world/World.js
+++ b/src/world/World.js
@@ -501,9 +501,8 @@ var step_mg = vec2.create(),
  */
 World.prototype.step = function(dt,timeSinceLastCalled,maxSubSteps){
     maxSubSteps = maxSubSteps || 10;
-    timeSinceLastCalled = timeSinceLastCalled || 0;
 
-    if(timeSinceLastCalled === 0){ // Fixed, simple stepping
+    if(timeSinceLastCalled === undefined){ // Fixed, simple stepping
 
         this.internalStep(dt);
 


### PR DESCRIPTION
Calling World.step with a `timeSinceLastCalled` of 0 would cause it to revert
to the fixed time step behaviour. This was due to the default value of
`timeSinceLastCalled` being 0. This change checks for `undefined`, as opposed
to 0.

`maxSubSteps` still has a default value of 10.

See issue #334 for more details.