### PR TITLE
RaycastResult: Ray is not a needed require

### DIFF
--- a/src/collision/RaycastResult.js
+++ b/src/collision/RaycastResult.js
@@ -1,5 +1,4 @@
 var vec2 = require('../math/vec2');
-var Ray = require('../collision/Ray');
 
 module.exports = RaycastResult;
 


### PR DESCRIPTION
When importing `Ray`, you end up with circular dependencies. Since it's not needed here, we can safely remove it.